### PR TITLE
Update Dasboard Pane Title in "Top Prefixes"

### DIFF
--- a/dashboards/obmp/Tops-1003/top_prefixes.json
+++ b/dashboards/obmp/Tops-1003/top_prefixes.json
@@ -379,7 +379,7 @@
           ]
         }
       ],
-      "title": "Withdraws  by Peer",
+      "title": "Withdraws  by Router",
       "type": "timeseries"
     },
     {


### PR DESCRIPTION
In the "Top Prefixes" dashboard, the pane regarding the "Withdraws by Router" has the wrong pane title. It is configured as "Withdraws by Peer", but this information is shown in a pane below.

Title as configured in the repo:
<img width="1753" alt="Screenshot 2022-10-10 at 14 47 40" src="https://user-images.githubusercontent.com/13032159/194870482-e97bce8d-c83a-46e8-adaf-6e30b9f194f5.png">

Updated title: 
<img width="1747" alt="Screenshot 2022-10-10 at 14 41 29" src="https://user-images.githubusercontent.com/13032159/194870437-9d208a18-da52-4a37-9b06-a8460e72ae66.png">



